### PR TITLE
Update Stripe.URI in 1.x.x to use implementation from 2.x.x

### DIFF
--- a/lib/stripe/uri.ex
+++ b/lib/stripe/uri.ex
@@ -28,7 +28,6 @@ defmodule Stripe.URI do
   }
   Stripe.URI.encode_query(card_data) # cards[0][number]=424242424242&cards[0][exp_year]=2014&cards[1][number]=424242424242&cards[1][exp_year]=2017
   """
-  @spec encode_query(map) :: String.t()
   def encode_query(map) do
     map |> UriQuery.params() |> URI.encode_query()
   end

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule Stripe.Mixfile do
   defp deps do
     [
       {:httpoison, ">= 0.0.0" },
+      {:uri_query, "~> 0.1.2"},
       {:poison, ">= 0.0.0", optional: true},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev},


### PR DESCRIPTION
I was running into an issue when trying to set [`requested_capabilities`](https://stripe.com/docs/api/accounts/create#create_account-requested_capabilities). The implementation of `Stripe.URI` in the 1.x.x. branch blows up when it encounters a list of strings.

Rather than updating the code to handle that scenario, I figured it best to just pull in the implementation from `master` which just uses `UriQuery` under the hood.