### PR TITLE
Update `Mix.Config` to the new `Config` module

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 if File.exists?("config/config.secret.exs") do
   import_config "config.secret.exs"


### PR DESCRIPTION
`Mix.Config` is deprecated.  This gets rid of a warning.

Fortunately the remaining config is simple enough there's nothing else to do. 