### PR TITLE
Add Early Fraud Warnings Types and Endpoint

### DIFF
--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -32,6 +32,7 @@ defmodule Stripe.Converter do
     discount
     dispute
     ephemeral_key
+    radar.early_fraud_warning
     event
     external_account
     file

--- a/lib/stripe/fraud/early_fraud_warnings.ex
+++ b/lib/stripe/fraud/early_fraud_warnings.ex
@@ -1,0 +1,80 @@
+defmodule Stripe.Fraud.EarlyFraudWarning do
+  @moduledoc """
+  Work with Stripe Radar Early Fraud Warnings objects.
+
+  You can:
+
+  - Retrieve an early fraud warning
+  - Retrieve all early fraud warnings
+
+  Stripe API reference: https://stripe.com/docs/api/radar/early_fraud_warnings
+  """
+
+  use Stripe.Entity
+  import Stripe.Request
+
+  @typedoc """
+  One of "card_never_received", or "fraudulent_card_application", or
+  "made_with_counterfeit_card", or "made_with_lost_card", or "made_with_stolen_card",
+  or "misc", or "unauthorized_use_of_card"
+  """
+  @type payment_status :: String.t()
+
+  @type t :: %__MODULE__{
+          id: Stripe.id(),
+          object: String.t(),
+          actionable: boolean(),
+          charge: Stripe.id() | Stripe.Charge.t() | nil,
+          created: Stripe.timestamp(),
+          fraud_type: String.t(),
+          livemode: boolean(),
+          payment_intent: Stripe.id() | Stripe.PaymentIntent.t() | nil
+        }
+
+  defstruct [
+    :id,
+    :object,
+    :actionable,
+    :charge,
+    :created,
+    :fraud_type,
+    :livemode,
+    :payment_intent
+  ]
+
+  @plural_endpoint "radar/early_fraud_warnings"
+
+  @doc ~S"""
+  Retrieve an Early Fraud Warning
+  """
+  @spec retrieve(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def retrieve(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:get)
+    |> make_request()
+  end
+
+  @doc ~S"""
+  Retrieve a list of Early Fraud Warnings
+  """
+  @spec list(params, Stripe.options()) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 optional(:charge) => Stripe.id() | Stripe.Charge.t(),
+                 optional(:payment_intent) => Stripe.id() | Stripe.PaymentIntent.t(),
+                 optional(:ending_before) => t | Stripe.id(),
+                 optional(:limit) => 1..100,
+                 optional(:starting_after) => t | Stripe.id()
+               }
+               | %{}
+  def list(params \\ %{}, opts \\ []) do
+    new_request(opts)
+    |> prefix_expansions()
+    |> put_endpoint(@plural_endpoint)
+    |> put_method(:get)
+    |> put_params(params)
+    |> cast_to_id([:charge, :ending_before, :starting_after])
+    |> make_request()
+  end
+end

--- a/lib/stripe/util.ex
+++ b/lib/stripe/util.ex
@@ -53,6 +53,7 @@ defmodule Stripe.Util do
   @spec object_name_to_module(String.t()) :: module
   def object_name_to_module("billing_portal.session"), do: Stripe.BillingPortal.Session
   def object_name_to_module("checkout.session"), do: Stripe.Session
+  def object_name_to_module("radar.early_fraud_warning"), do: Stripe.Fraud.EarlyFraudWarning
   def object_name_to_module("file"), do: Stripe.FileUpload
 
   def object_name_to_module("identity.verification_session"),

--- a/mix.exs
+++ b/mix.exs
@@ -173,6 +173,7 @@ defmodule Stripe.Mixfile do
         Stripe.TransferReversal
       ],
       Fraud: [
+        Stripe.Fraud.EarlyFraudWarning,
         Stripe.Review
       ],
       Identity: [

--- a/test/stripe/fraud/early_fraud_warnings_test.exs
+++ b/test/stripe/fraud/early_fraud_warnings_test.exs
@@ -1,0 +1,21 @@
+defmodule Stripe.EarlyFraudWarningsTest do
+  use Stripe.StripeCase, async: true
+
+  describe "retrieve/2" do
+    test "is retrievable" do
+      assert {:ok, %Stripe.Fraud.EarlyFraudWarning{}} =
+               Stripe.Fraud.EarlyFraudWarning.retrieve("issfr_123")
+
+      assert_stripe_requested(:get, "/v1/radar/early_fraud_warnings/issfr_123")
+    end
+  end
+
+  describe "list/2" do
+    test "is listable" do
+      assert {:ok, %Stripe.List{data: efws}} = Stripe.Fraud.EarlyFraudWarning.list()
+      assert_stripe_requested(:get, "/v1/radar/early_fraud_warnings")
+      assert is_list(efws)
+      assert %Stripe.Fraud.EarlyFraudWarning{} = hd(efws)
+    end
+  end
+end


### PR DESCRIPTION
Add early fraud warnings types and endpoint, as well as tests

Endpoint documented in:  https://stripe.com/docs/api/radar/early_fraud_warnings

This is a "read only" object (from the customer's perspective) so there are no
create or update endpoints for it.