### PR TITLE
Idempotency should only be added for :post

### DIFF
--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -385,13 +385,13 @@ defmodule Stripe.API do
       headers,
       body,
       opts,
-      add_attempts(response, attempts, retry_config())
+      add_attempts(method, response, attempts, retry_config())
     )
   end
 
-  @spec add_attempts(http_success | http_failure, non_neg_integer, Keyword.t()) ::
+  @spec add_attempts(method, http_success | http_failure, non_neg_integer, Keyword.t()) ::
           {:attempts, non_neg_integer} | {:response, http_success | http_failure}
-  defp add_attempts(response, attempts, retry_config) do
+  defp add_attempts(method, response, attempts, retry_config) when method in [:post, :patch] do
     if should_retry?(response, attempts, retry_config) do
       attempts
       |> backoff(retry_config)
@@ -401,6 +401,10 @@ defmodule Stripe.API do
     else
       {:response, response}
     end
+  end
+
+  defp add_attempts(_method, response, attempts, retry_config) do
+    {:response, response}
   end
 
   @doc """

--- a/test/stripe/api_test.exs
+++ b/test/stripe/api_test.exs
@@ -121,7 +121,6 @@ defmodule Stripe.APITest do
     assert Map.keys(body) |> Enum.member?("Authorization") == false
   end
 
-  @tag :wip
   test "reads hackney timeout opts from config" do
     # Return request opts as response body
     defmodule HackneyMock do


### PR DESCRIPTION
Idempotency should only be added for :post.  Stripe API is organized around REST and based on the HTTP [spec](https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.2), PUT and DELETE are idempotent.  An idempotency key is only needed for POST.

close https://github.com/beam-community/stripity_stripe/issues/711

docs https://stripe.com/docs/api/idempotent_requests

> All POST requests accept idempotency keys. Sending idempotency keys in GET and DELETE requests has no effect and should be avoided, as these requests are idempotent by definition.