### PR TITLE
fix credit note line item spec

### DIFF
--- a/lib/stripe/subscriptions/credit_note.ex
+++ b/lib/stripe/subscriptions/credit_note.ex
@@ -39,7 +39,7 @@ defmodule Stripe.CreditNote do
           discount_amount: integer,
           discount_amounts: [discount],
           invoice: Stripe.id() | Stripe.Invoice.t(),
-          lines: Stripe.List.t(Stripe.LineItem.t()),
+          lines: Stripe.List.t(Stripe.CreditNoteLineItem.t()),
           livemode: boolean,
           memo: String.t(),
           metadata: Stripe.Types.metadata(),


### PR DESCRIPTION
just a simple typespec fix for CreditNote
https://stripe.com/docs/api/credit_notes/retrieve
`lines` should contain `CreditNoteLineItem` instead.

**CreditNote**
https://github.com/beam-community/stripity_stripe/blob/master/lib/stripe/subscriptions/credit_note.ex
**CreditNoteLineItem**
https://github.com/beam-community/stripity_stripe/blob/master/lib/stripe/subscriptions/credit_note_line_item.ex