### PR TITLE
Fix create/update subscription spec

### DIFF
--- a/lib/stripe/subscriptions/subscription.ex
+++ b/lib/stripe/subscriptions/subscription.ex
@@ -157,7 +157,7 @@ defmodule Stripe.Subscription do
                optional(:proration_behavior) => String.t(),
                optional(:promotion_code) => Stripe.id(),
                optional(:tax_percent) => float,
-               optional(:trial_end) => Stripe.timestamp(),
+               optional(:trial_end) => Stripe.timestamp() | :now,
                optional(:trial_from_plan) => boolean,
                optional(:trial_period_days) => non_neg_integer
              }
@@ -217,7 +217,7 @@ defmodule Stripe.Subscription do
                optional(:proration_behavior) => String.t(),
                optional(:proration_date) => Stripe.timestamp(),
                optional(:tax_percent) => float,
-               optional(:trial_end) => Stripe.timestamp(),
+               optional(:trial_end) => Stripe.timestamp() | :now,
                optional(:trial_from_plan) => boolean
              }
   def update(id, params, opts \\ []) do


### PR DESCRIPTION
According to Stripe, a special value of `now` can be provided to end the subscription trial immediately.

Doc for create subscription: https://stripe.com/docs/api/subscriptions/create#create_subscription-trial_end
Doc for update subscription: https://stripe.com/docs/api/subscriptions/update#update_subscription-trial_end