### PR TITLE
Add us_bank_account & more debits to PaymentMethod

### DIFF
--- a/lib/stripe/payment_methods/payment_method.ex
+++ b/lib/stripe/payment_methods/payment_method.ex
@@ -8,10 +8,24 @@ defmodule Stripe.PaymentMethod do
   use Stripe.Entity
   import Stripe.Request
 
+  @type acss_debit :: %{
+          bank_name: String.t() | nil,
+          fingerprint: String.t() | nil,
+          institution_number: String.t() | nil,
+          last4: String.t() | nil,
+          transit_number: String.t() | nil
+        }
+
   @type au_becs_debit :: %{
           bsb_number: String.t(),
           fingerprint: String.t(),
           last4: String.t()
+        }
+
+  @type bacs_debit :: %{
+          fingerprint: String.t() | nil,
+          last4: String.t() | nil,
+          sort_code: String.t() | nil
         }
 
   @type sepa_debit :: %{
@@ -20,6 +34,17 @@ defmodule Stripe.PaymentMethod do
           country: String.t() | nil,
           fingerprint: String.t() | nil,
           last4: String.t() | nil
+        }
+
+  @type us_bank_account :: %{
+          account_holder_type: String.t() | nil,
+          account_type: String.t() | nil,
+          bank_name: String.t() | nil,
+          financial_connections_account: String.t() | nil,
+          fingerprint: String.t() | nil,
+          last4: String.t() | nil,
+          networks: %{preferred: String.t() | nil, supported: list | nil} | nil,
+          routing_number: String.t() | nil
         }
 
   @type t :: %__MODULE__{
@@ -37,8 +62,11 @@ defmodule Stripe.PaymentMethod do
           link: %{persistent_token: String.t() | nil} | nil,
           livemode: boolean,
           metadata: Stripe.Types.metadata(),
+          acss_debit: acss_debit() | nil,
           au_becs_debit: au_becs_debit() | nil,
+          bacs_debit: bacs_debit() | nil,
           sepa_debit: sepa_debit() | nil,
+          us_bank_account: us_bank_account() | nil,
           type: String.t()
         }
 
@@ -52,8 +80,11 @@ defmodule Stripe.PaymentMethod do
     :link,
     :livemode,
     :metadata,
+    :acss_debit,
     :au_becs_debit,
+    :bacs_debit,
     :sepa_debit,
+    :us_bank_account,
     :type
   ]
 


### PR DESCRIPTION
Currently, the `Stripe.PaymentMethod` struct doesn't include a number of fields that the Stripe API uses for the type-specific details of a payment method. This change adds fields for the bank-debit payment types that are missing:

* `us_bank_account`
* `acss_debit`
* `bacs_debit`

Retreiving a `us_bank_account` payment type should now populate its `us_bank_account` field:

```
iex> Stripe.PaymentMethod.retrieve("pm_1LHCTyLbyeJk2hS7DM11RAja")
{:ok,
 %Stripe.PaymentMethod{
   acss_debit: nil,
   au_becs_debit: nil,
   bacs_debit: nil,
   billing_details: %{...},
   card: nil,
   created: 1656791998,
   customer: "cus_KKy0ZBqhtEbzGT",
   id: "pm_1LHCTyLbyeJk2hS7DM11RAja",
   link: nil,
   livemode: false,
   metadata: %{},
   object: "payment_method",
   sepa_debit: nil,
   type: "us_bank_account",
   us_bank_account: %{
     account_holder_type: "individual",
     account_type: "checking",
     bank_name: "STRIPE TEST BANK",
     financial_connections_account: "fca_1LHCSdLhelJl1gS70hOa1j2X",
     fingerprint: "xxFq7llo9dS1Z7bU",
     last4: "6789",
     networks: %{preferred: "ach", supported: ["ach"]},
     routing_number: "110000000"
   }
 }}
```

And retreiving a `acss_debit` payment type should now populate its `acss_debit` field:

```
iex> Stripe.PaymentMethod.retrieve("pm_1LHHg4LbyeJtr2S7BRfSddnr")
{:ok,
 %Stripe.PaymentMethod{
   acss_debit: %{
     bank_name: "STRIPE TEST BANK",
     fingerprint: "22KHkQTs0hGFjFCw",
     institution_number: "000",
     last4: "6789",
     transit_number: "11000"
   },
   au_becs_debit: nil,
   bacs_debit: nil,
   billing_details: %{...},
   card: nil,
   created: 1656811968,
   customer: "cus_KKy0ZBqhtEbzGT",
   id: "pm_1LHHg4LbyeJtr2S7BRfSddnr",
   link: nil,
   livemode: false,
   metadata: %{},
   object: "payment_method",
   sepa_debit: nil,
   type: "acss_debit",
   us_bank_account: nil
 }}
```

And retreiving a `bacs_debit` payment type should now populate its `bacs_debit` field:

```
iex> Stripe.PaymentMethod.retrieve("pm_1JxiLYLbyeJp3tS7S6m9FXa0")
{:ok,
 %Stripe.PaymentMethod{
   acss_debit: nil,
   au_becs_debit: nil,
   bacs_debit: %{
     fingerprint: "3id8WkuR8aycGzht",
     last4: "2345",
     sort_code: "108800"
   },
   billing_details: %{...},
   card: nil,
   created: 1637371588,
   customer: "cus_KKy0ZBqhtEbzGT",
   id: "pm_1JxiLYLbyeJp3tS7S6m9FXa0",
   link: nil,
   livemode: false,
   metadata: %{},
   object: "payment_method",
   sepa_debit: nil,
   type: "bacs_debit",
   us_bank_account: nil
 }}
```
