### PR TITLE
Stripe API version 2020-08-27

### DIFF
--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -16,7 +16,7 @@ defmodule Stripe.API do
   @typep http_failure :: {:error, term}
 
   @pool_name __MODULE__
-  @api_version "2019-12-03"
+  @api_version "2020-08-27"
 
   @idempotency_key_header "Idempotency-Key"
 

--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -171,7 +171,7 @@ defmodule Stripe.Session do
             optional(:price) => String.t(),
             optional(:price_data) => price_data,
             optional(:taxes) => list(map),
-          }
+          },
           optional(:has_more) => boolean,
           optional(:url) => String.t(),
         }

--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -155,17 +155,25 @@ defmodule Stripe.Session do
         }
 
   @type line_item :: %{
-          optional(:name) => String.t(),
-          optional(:quantity) => integer(),
-          optional(:adjustable_quantity) => adjustable_quantity(),
-          optional(:amount) => integer(),
-          optional(:currency) => String.t(),
-          optional(:description) => String.t(),
-          optional(:dynamic_tax_rates) => list(String.t()),
-          optional(:images) => list(String.t()),
-          optional(:price) => String.t(),
-          optional(:price_data) => price_data,
-          optional(:tax_rates) => list(String.t())
+          optional(:object) => String.t(),
+          optional(:data) => %{
+            optional(:id) => Stripe.id(),
+            optional(:object) => String.t(),
+            optional(:quantity) => integer(),
+            optional(:amount_discount) => integer(),
+            optional(:amount_subtotal) => integer(),
+            optional(:amount_tax) => integer(),
+            optional(:amount_total) => integer(),
+            optional(:currency) => String.t(),
+            optional(:description) => String.t(),
+            optional(:discounts) => list(map),
+            optional(:dynamic_tax_rates) => list(String.t()),
+            optional(:price) => String.t(),
+            optional(:price_data) => price_data,
+            optional(:taxes) => list(map),
+          }
+          optional(:has_more) => boolean,
+          optional(:url) => String.t(),
         }
 
   @type adjustable_quantity :: %{
@@ -300,7 +308,7 @@ defmodule Stripe.Session do
           customer_creation: customer_creation() | nil,
           customer_details: customer_details() | nil,
           customer_email: String.t(),
-          display_items: list(line_item),
+          line_items: list(line_item),
           expires_at: Stripe.timestamp() | nil,
           livemode: boolean(),
           locale: boolean(),
@@ -348,7 +356,7 @@ defmodule Stripe.Session do
     :customer_creation,
     :customer_details,
     :customer_email,
-    :display_items,
+    :line_items,
     :expires_at,
     :livemode,
     :locale,

--- a/lib/stripe/payment_methods/source.ex
+++ b/lib/stripe/payment_methods/source.ex
@@ -158,7 +158,7 @@ defmodule Stripe.Source do
         }
 
   @type three_d_secure :: %{
-          authenticated: boolean | nil,
+          result: String.t() | nil,
           card: String.t() | nil,
           customer: String.t() | nil
         }

--- a/lib/stripe/subscriptions/invoice.ex
+++ b/lib/stripe/subscriptions/invoice.ex
@@ -81,7 +81,7 @@ defmodule Stripe.Invoice do
           subscription_proration_date: Stripe.timestamp() | nil,
           subtotal: integer,
           tax: integer | nil,
-          tax_percent: number | nil,
+          tax_rate: Stripe.id() | Stripe.TaxRate.t() | nil,
           threshold_reason:
             nil
             | %{
@@ -183,7 +183,7 @@ defmodule Stripe.Invoice do
     :subscription_proration_date,
     :subtotal,
     :tax,
-    :tax_percent,
+    :tax_rate,
     :threshold_reason,
     :total,
     :total_discount_amounts,
@@ -206,8 +206,10 @@ defmodule Stripe.Invoice do
   @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
                %{
+                 optional(:account_tax_ids) => list(String.t()),
                  optional(:application_fee_amount) => integer,
                  optional(:auto_advance) => boolean,
+                 optional(:automatic_tax) => map,
                  optional(:collection_method) => String.t(),
                  :customer => Stripe.id() | Stripe.Customer.t(),
                  optional(:custom_fields) => custom_fields,
@@ -216,12 +218,13 @@ defmodule Stripe.Invoice do
                  optional(:default_source) => String.t(),
                  optional(:default_tax_rates) => [Stripe.id()],
                  optional(:description) => String.t(),
+                 optional(:discounts) => list(String.t()),
                  optional(:due_date) => Stripe.timestamp(),
                  optional(:footer) => String.t(),
                  optional(:metadata) => Stripe.Types.metadata(),
+                 optional(:payment_settings) => map,
                  optional(:statement_descriptor) => String.t(),
                  optional(:subscription) => Stripe.id() | Stripe.Subscription.t(),
-                 optional(:tax_percent) => number
                }
                | %{}
   def create(params, opts \\ []) do
@@ -260,21 +263,24 @@ defmodule Stripe.Invoice do
   @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
                %{
+                 optional(:account_tax_ids) => list(String.t()),
                  optional(:application_fee_amount) => integer,
                  optional(:auto_advance) => boolean,
+                 optional(:automatic_tax) => map,
                  optional(:custom_fields) => custom_fields,
                  optional(:days_until_due) => integer,
                  optional(:default_payment_method) => String.t(),
                  optional(:default_source) => String.t(),
                  optional(:default_tax_rates) => [Stripe.id()],
                  optional(:description) => String.t(),
+                 optional(:discounts) => list(String.t()),
                  optional(:due_date) => Stripe.timestamp(),
                  optional(:footer) => String.t(),
                  optional(:forgiven) => boolean,
                  optional(:metadata) => Stripe.Types.metadata(),
                  optional(:paid) => boolean,
+                 optional(:payment_settings) => map,
                  optional(:statement_descriptor) => String.t(),
-                 optional(:tax_percent) => number
                }
                | %{}
   def update(id, params, opts \\ []) do

--- a/lib/stripe/subscriptions/subscription.ex
+++ b/lib/stripe/subscriptions/subscription.ex
@@ -113,6 +113,7 @@ defmodule Stripe.Subscription do
     :pending_update,
     :plan,
     :pause_collection,
+    :promotion_code,
     :quantity,
     :schedule,
     :start_date,
@@ -160,7 +161,7 @@ defmodule Stripe.Subscription do
                optional(:prorate) => boolean,
                optional(:proration_behavior) => String.t(),
                optional(:promotion_code) => Stripe.id(),
-               optional(:tax_rate) => Stripe.id() | Stripe.TaxRate.t()
+               optional(:tax_rate) => Stripe.id() | Stripe.TaxRate.t(),
                optional(:trial_end) => Stripe.timestamp() | :now,
                optional(:trial_from_plan) => boolean,
                optional(:trial_period_days) => non_neg_integer
@@ -220,7 +221,7 @@ defmodule Stripe.Subscription do
                optional(:prorate) => boolean,
                optional(:proration_behavior) => String.t(),
                optional(:proration_date) => Stripe.timestamp(),
-                optional(:tax_rate) => Stripe.id() | Stripe.TaxRate.t()
+               optional(:tax_rate) => Stripe.id() | Stripe.TaxRate.t(),
                optional(:trial_end) => Stripe.timestamp() | :now,
                optional(:trial_from_plan) => boolean
              }

--- a/lib/stripe/subscriptions/subscription.ex
+++ b/lib/stripe/subscriptions/subscription.ex
@@ -15,7 +15,6 @@ defmodule Stripe.Subscription do
 
   use Stripe.Entity
   import Stripe.Request
-  import Stripe.Util, only: [log_deprecation: 1]
 
   @type pause_collection :: %{
           behavior: String.t(),

--- a/lib/stripe/subscriptions/subscription_schedule.ex
+++ b/lib/stripe/subscriptions/subscription_schedule.ex
@@ -7,19 +7,24 @@ defmodule Stripe.SubscriptionSchedule do
   use Stripe.Entity
   import Stripe.Request
 
-  @type plans :: %{
-          plan: String.t(),
+  @type items :: %{
+          billing_thresholds: Stripe.Types.collection_method_thresholds(),
           price: String.t(),
-          quantity: pos_integer
+          quantity: pos_integer,
+          tax_rates: [Stripe.TaxRate.t()],
         }
 
   @type phases :: %{
+          collection_method: string | nil,
+          collection_method: string | nil,
+          coupon: string | nil,
+          default_payment_method: string | nil,
+          default_tax_rates: float | nil,
           application_fee_percent: float | nil,
           end_date: Stripe.timestamp(),
           start_date: Stripe.timestamp(),
-          tax_percent: float | nil,
           trial_end: Stripe.timestamp(),
-          plans: list(plans)
+          items: list(items)
         }
 
   @type default_settings :: %{
@@ -49,6 +54,7 @@ defmodule Stripe.SubscriptionSchedule do
           revision: String.t(),
           status: String.t(),
           subscription: Stripe.id() | Stripe.Subscription.t(),
+          test_clock: Stripe.id() | Stripe.Subscription.t(),
           customer: Stripe.id() | Stripe.Customer.t(),
           released_subscription: Stripe.id() | Stripe.Subscription.t() | nil,
           phases: list(phases)
@@ -71,7 +77,8 @@ defmodule Stripe.SubscriptionSchedule do
     :livemode,
     :metadata,
     :end_behavior,
-    :revision
+    :revision,
+    :test_clock,
   ]
 
   @plural_endpoint "subscription_schedules"
@@ -98,11 +105,12 @@ defmodule Stripe.SubscriptionSchedule do
                },
                optional(:phases) => [
                  %{
-                   :plans => [
+                   :items => [
                      %{
-                       optional(:plan) => Stripe.id() | Stripe.Plan.t(),
+                       optional(:billing_thresholds): Stripe.Types.collection_method_thresholds()
                        optional(:price) => Stripe.id() | Stripe.Price.t(),
-                       optional(:quantity) => non_neg_integer
+                       optional(:quantity) => non_neg_integer,
+                       optional(:tax_rates) => [Stripe.TaxRate.t()]
                      }
                    ],
                    optional(:application_fee_percent) => non_neg_integer,
@@ -110,7 +118,6 @@ defmodule Stripe.SubscriptionSchedule do
                    optional(:end_date) => Stripe.timestamp(),
                    optional(:iterations) => non_neg_integer,
                    optional(:start_date) => Stripe.timestamp(),
-                   optional(:tax_percent) => float,
                    optional(:trial) => boolean(),
                    optional(:trial_end) => Stripe.timestamp()
                  }
@@ -152,11 +159,12 @@ defmodule Stripe.SubscriptionSchedule do
                },
                optional(:phases) => [
                  %{
-                   :plans => [
+                   :items => [
                      %{
-                       optional(:plan) => Stripe.id() | Stripe.Plan.t(),
+                       optional(:billing_thresholds): Stripe.Types.collection_method_thresholds() | nil,
                        optional(:price) => Stripe.id() | Stripe.Price.t(),
                        optional(:quantity) => non_neg_integer
+                       optional(:tax_rates) => [Stripe.TaxRate.t()]
                      }
                    ],
                    optional(:application_fee_percent) => non_neg_integer,
@@ -164,7 +172,6 @@ defmodule Stripe.SubscriptionSchedule do
                    optional(:end_date) => Stripe.timestamp(),
                    optional(:iterations) => non_neg_integer,
                    optional(:start_date) => Stripe.timestamp(),
-                   optional(:tax_percent) => float,
                    optional(:trial) => boolean(),
                    optional(:trial_end) => Stripe.timestamp()
                  }

--- a/lib/stripe/subscriptions/subscription_schedule.ex
+++ b/lib/stripe/subscriptions/subscription_schedule.ex
@@ -107,7 +107,7 @@ defmodule Stripe.SubscriptionSchedule do
                  %{
                    :items => [
                      %{
-                       optional(:billing_thresholds): Stripe.Types.collection_method_thresholds()
+                       optional(:billing_thresholds) => Stripe.Types.collection_method_thresholds(),
                        optional(:price) => Stripe.id() | Stripe.Price.t(),
                        optional(:quantity) => non_neg_integer,
                        optional(:tax_rates) => [Stripe.TaxRate.t()]
@@ -161,9 +161,9 @@ defmodule Stripe.SubscriptionSchedule do
                  %{
                    :items => [
                      %{
-                       optional(:billing_thresholds): Stripe.Types.collection_method_thresholds() | nil,
+                       optional(:billing_thresholds) => Stripe.Types.collection_method_thresholds(),
                        optional(:price) => Stripe.id() | Stripe.Price.t(),
-                       optional(:quantity) => non_neg_integer
+                       optional(:quantity) => non_neg_integer,
                        optional(:tax_rates) => [Stripe.TaxRate.t()]
                      }
                    ],

--- a/lib/stripe/subscriptions/subscription_schedule.ex
+++ b/lib/stripe/subscriptions/subscription_schedule.ex
@@ -15,10 +15,10 @@ defmodule Stripe.SubscriptionSchedule do
         }
 
   @type phases :: %{
-          collection_method: string | nil,
-          collection_method: string | nil,
-          coupon: string | nil,
-          default_payment_method: string | nil,
+          collection_method: String.t() | nil,
+          collection_method: String.t() | nil,
+          coupon: String.t() | nil,
+          default_payment_method: String.t() | nil,
           default_tax_rates: float | nil,
           application_fee_percent: float | nil,
           end_date: Stripe.timestamp(),

--- a/test/stripe/api_test.exs
+++ b/test/stripe/api_test.exs
@@ -85,7 +85,7 @@ defmodule Stripe.APITest do
 
   test "gets default api version" do
     Stripe.API.request(%{}, :get, "products", %{}, [])
-    assert_stripe_requested(:get, "/v1/products", headers: {"Stripe-Version", "2019-12-03"})
+    assert_stripe_requested(:get, "/v1/products", headers: {"Stripe-Version", "2020-08-27"})
   end
 
   test "can set custom api version" do

--- a/test/stripe/subscriptions/subscription_schedule_test.exs
+++ b/test/stripe/subscriptions/subscription_schedule_test.exs
@@ -10,7 +10,6 @@ defmodule Stripe.SubscriptionScheduleTest do
         default_tax_rates: [],
         end_date: 1_557_566_037,
         start_date: 1_554_974_037,
-        tax_percent: 0
       }
     ]
   }
@@ -35,13 +34,11 @@ defmodule Stripe.SubscriptionScheduleTest do
             end_date: 1_557_566_037,
             items: [
               %{
-                plan: "some plan",
                 quantity: 2,
                 tax_rates: []
               }
             ],
             start_date: 1_554_974_037,
-            tax_percent: 0
           }
         ]
       }
@@ -70,13 +67,11 @@ defmodule Stripe.SubscriptionScheduleTest do
             end_date: 1_557_566_037,
             items: [
               %{
-                plan: "some plan",
                 quantity: 2,
                 tax_rates: []
               }
             ],
             start_date: 1_554_974_037,
-            tax_percent: 0
           }
         ]
       }

--- a/test/stripe/subscriptions/subscription_test.exs
+++ b/test/stripe/subscriptions/subscription_test.exs
@@ -59,58 +59,6 @@ defmodule Stripe.SubscriptionTest do
     end
   end
 
-  describe "delete/1" do
-    test "deletes a subscription" do
-      assert {:ok, %Stripe.Subscription{} = subscription} = Stripe.Subscription.delete("sub_123")
-      assert_stripe_requested(:delete, "/v1/subscriptions/#{subscription.id}")
-    end
-  end
-
-  describe "delete/2" do
-    test "deletes a subscription when second argument is a list" do
-      assert {:ok, %Stripe.Subscription{} = subscription} =
-               Stripe.Subscription.delete("sub_123", [])
-
-      assert_stripe_requested(:delete, "/v1/subscriptions/#{subscription.id}")
-    end
-
-    test "deletes a subscription when second argument is a map" do
-      assert {:ok, %Stripe.Subscription{} = subscription} =
-               Stripe.Subscription.delete("sub_123", %{})
-
-      assert_stripe_requested(:delete, "/v1/subscriptions/#{subscription.id}")
-    end
-
-    test "with `at_period_end` is deprecated [since 2018-08-23]" do
-      assert {:ok, %Stripe.Subscription{} = subscription} =
-               Stripe.Subscription.delete("sub_123", %{at_period_end: true})
-
-      assert subscription.cancel_at_period_end
-
-      # The deprecated function acts as a facade for `cancel_at_period_end: true`.
-      assert_stripe_requested(:post, "/v1/subscriptions/#{subscription.id}")
-    end
-  end
-
-  describe "delete/3" do
-    test "with `at_period_end` is deprecated [since 2018-08-23]" do
-      assert {:ok, %Stripe.Subscription{cancel_at_period_end: true}} =
-               Stripe.Subscription.delete("sub_123", %{at_period_end: true}, [])
-
-      # The deprecated function acts as a facade for `cancel_at_period_end: true`.
-      assert_stripe_requested(:post, "/v1/subscriptions/sub_123")
-    end
-
-    test "deletes a subscription with provided cancellation params" do
-      params = %{invoice_now: true, prorate: true}
-
-      assert {:ok, %Stripe.Subscription{} = subscription} =
-               Stripe.Subscription.delete("sub_123", params)
-
-      assert_stripe_requested(:delete, "/v1/subscriptions/#{subscription.id}", body: params)
-    end
-  end
-
   describe "list/2" do
     test "lists all subscriptions" do
       assert {:ok, %Stripe.List{data: subscriptions}} = Stripe.Subscription.list()


### PR DESCRIPTION
https://stripe.com/docs/upgrades#2020-08-27

- [x] We have removed tax_percent from objects and requests in favor of [tax rates](https://stripe.com/docs/api/tax_rates).
- [x] On subscription schedules, phases.plans has been renamed to phases.items. This applies for the [subscription schedule](https://stripe.com/docs/api/subscription_schedules/object#subscription_schedule_object-phases) object as well as [create](https://stripe.com/docs/api/subscription_schedules/create#create_subscription_schedule-phases) and [update](https://stripe.com/docs/api/subscription_schedules/update#update_subscription_schedule-phases) requests.
- [x] Deprecate the payment_method.card_automatically_updated webhook in favor of payment_method.automatically_updated.
- [x] Checkout Sessions no longer include the display_items property. Use the includable line_items property instead.
- [x] The requirements hash on the Account and Capability objects, and the verification_fields hash on the Country Spec object have newly formatted strings for requirements that are related to key persons associated with an account:
- Fields that are required for persons with representative, owner, director, and executive roles will be prefixed with representative, owners, directors, and executives, respectively. Person requirements will be previewed as follows:
- When the representative’s phone number is required, it will appear as representative.phone instead of relationship.representative.
- When an owner’s full name is required, it will appear as owners.first_name and owners.last_name instead of relationship.owner.
- When an executive’s ID number is required, it will appear as executives.id_number instead of relationship.executive.
- When a director’s date of birth is required, it will appear as directors.dob.day, directors.dob.month, and directors.dob.year instead of relationship.director.
- The boolean values that indicate the associated owners, executives, or directors have been provided now appear as company.owners_provided, company.executives_provided, or company.directors_provided instead of relationship.owner, relationship.executive, or relationship.director, respectively.
- [x] In the Accounts/Persons/Capabilities API, several new error codes have been introduced in the requirements.errors array. See [Account requirements errors](https://stripe.com/docs/api/accounts/object#account_object-requirements-errors) for more information. - [ ] These error codes are:
verification_document_issue_or_expiry_date_missing
verification_document_not_signed
verification_failed_tax_id_not_issued
verification_failed_tax_id_match
invalid_address_po_boxes_disallowed
- [x] The payment_method_details.card.three_d_secure fields on the Charge object have been updated. The succeeded and authenticated booleans have been removed; please use the result enum instead.
- [x] The subscriptions property on Customers is no longer included by default. You can [expand the list](https://stripe.com/docs/api#expanding_objects) but for performance reasons we recommended against doing so unless needed.
- [x] The tiers property on Plan is no longer included by default. You can [expand the list](https://stripe.com/docs/api#expanding_objects) but for performance reasons we recommended against doing so unless needed.
- [x] The sources property on Customers is no longer included by default. You can [expand the list](https://stripe.com/docs/api#expanding_objects) but for performance reasons we recommended against doing so unless needed.
- [x] The tax_ids property on Customers is no longer included by default. You can [expand the list](https://stripe.com/docs/api#expanding_objects) but for performance reasons we recommended against doing so unless needed.
- [x] The prorate and subscription_prorate parameters are deprecated in favor of proration_behavior.

https://stripe.com/docs/upgrades#breaking-change