### PR TITLE
Add reporting entities

### DIFF
--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -144,7 +144,8 @@ defmodule Stripe.API do
   end
 
   @spec add_idempotency_headers(headers, method) :: headers
-  defp add_idempotency_headers(existing_headers, method) when method in [:get, :head, :put, :delete] do
+  defp add_idempotency_headers(existing_headers, method)
+       when method in [:get, :head, :put, :delete] do
     existing_headers
   end
 

--- a/lib/stripe/billing_portal/session.ex
+++ b/lib/stripe/billing_portal/session.ex
@@ -24,7 +24,7 @@ defmodule Stripe.BillingPortal.Session do
 
   @type create_params :: %{
           :customer => String.t(),
-          optional(:return_url) => String.t(), 
+          optional(:return_url) => String.t(),
           optional(:locale) => String.t()
         }
 

--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -170,10 +170,10 @@ defmodule Stripe.Session do
             optional(:dynamic_tax_rates) => list(String.t()),
             optional(:price) => String.t(),
             optional(:price_data) => price_data,
-            optional(:taxes) => list(map),
+            optional(:taxes) => list(map)
           },
           optional(:has_more) => boolean,
-          optional(:url) => String.t(),
+          optional(:url) => String.t()
         }
 
   @type adjustable_quantity :: %{
@@ -277,13 +277,13 @@ defmodule Stripe.Session do
   @type payment_status :: String.t()
 
   @type phone_number_collection :: %{
-    :enabled => boolean()
-  }
+          :enabled => boolean()
+        }
 
   @type shipping_option :: %{
-    :shipping_amount => non_neg_integer(),
-    :shipping_rate => String.t()
-  }
+          :shipping_amount => non_neg_integer(),
+          :shipping_rate => String.t()
+        }
 
   @typedoc """
   One of `"open"`, `"complete"`, or `"expired"`.

--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -64,6 +64,8 @@ defmodule Stripe.Converter do
     promotion_code
     recipient
     refund
+    reporting.report_run
+    reporting.report_type
     review
     search_result
     setup_intent

--- a/lib/stripe/error.ex
+++ b/lib/stripe/error.ex
@@ -123,9 +123,7 @@ defmodule Stripe.Error do
       source: :network,
       code: :network_error,
       message:
-        "An error occurred while making the network request. The HTTP client returned the following reason: #{
-          inspect(reason)
-        }",
+        "An error occurred while making the network request. The HTTP client returned the following reason: #{inspect(reason)}",
       extra: %{
         hackney_reason: reason
       }

--- a/lib/stripe/reporting/report_run.ex
+++ b/lib/stripe/reporting/report_run.ex
@@ -1,0 +1,89 @@
+defmodule Stripe.Reporting.ReportRun do
+  @moduledoc """
+  Work with Stripe Report Run objects.
+
+  You can:
+
+  - Create a report run
+  - Retrieve a report run
+  - List all report runs
+
+  Stripe API reference: https://stripe.com/docs/api/reporting/report_run
+  """
+
+  use Stripe.Entity
+  import Stripe.Request
+
+  @typedoc """
+  One of `"pending"`, `"succeeded"`, or `"failed"`.
+  """
+  @type status :: String.t()
+
+  @type t :: %__MODULE__{
+          id: Stripe.id(),
+          object: String.t(),
+          parameters: map(),
+          report_type: String.t(),
+          result: map(),
+          status: status(),
+          created: Stripe.timestamp(),
+          error: String.t(),
+          livemode: boolean(),
+          succeeded_at: Stripe.timestamp()
+        }
+
+  defstruct [
+    :id,
+    :object,
+    :parameters,
+    :report_type,
+    :result,
+    :status,
+    :created,
+    :error,
+    :livemode,
+    :succeeded_at
+  ]
+
+  @plural_endpoint "reporting/report_runs"
+
+  @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 :report_type => String.t(),
+                 optional(:parameters) => map()
+               }
+               | %{}
+  def create(params, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint)
+    |> put_params(params)
+    |> put_method(:post)
+    |> make_request()
+  end
+
+  @spec retrieve(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def retrieve(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:get)
+    |> make_request()
+  end
+
+  @spec list(params, Stripe.options()) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}
+        when params: %{
+               optional(:created) => Stripe.date_query(),
+               optional(:ending_before) => t | Stripe.id(),
+               optional(:limit) => 1..100,
+               optional(:starting_after) => t | Stripe.id()
+             }
+  def list(params \\ %{}, opts \\ []) do
+    new_request(opts)
+    |> prefix_expansions()
+    |> put_endpoint(@plural_endpoint)
+    |> put_method(:get)
+    |> put_params(params)
+    |> cast_to_id([:ending_before, :starting_after])
+    |> make_request()
+  end
+end

--- a/lib/stripe/reporting/report_type.ex
+++ b/lib/stripe/reporting/report_type.ex
@@ -1,0 +1,58 @@
+defmodule Stripe.Reporting.ReportType do
+  @moduledoc """
+  Work with Stripe Report Type objects.
+
+  You can:
+
+  - Retrieve a report type
+  - List all report types
+
+  Stripe API reference: https://stripe.com/docs/api/reporting/report_type
+  """
+
+  use Stripe.Entity
+  import Stripe.Request
+
+  @type t :: %__MODULE__{
+          id: Stripe.id(),
+          object: String.t(),
+          data_available_end: Stripe.timestamp(),
+          data_available_start: Stripe.timestamp(),
+          name: String.t(),
+          default_columns: list(String.t()),
+          livemode: boolean(),
+          updated: Stripe.timestamp(),
+          version: integer()
+        }
+
+  defstruct [
+    :id,
+    :object,
+    :data_available_end,
+    :data_available_start,
+    :name,
+    :default_columns,
+    :livemode,
+    :updated,
+    :version
+  ]
+
+  @plural_endpoint "reporting/report_types"
+
+  @spec retrieve(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def retrieve(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:get)
+    |> make_request()
+  end
+
+  @spec list(Stripe.options()) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}
+  def list(opts \\ []) do
+    new_request(opts)
+    |> prefix_expansions()
+    |> put_endpoint(@plural_endpoint)
+    |> put_method(:get)
+    |> make_request()
+  end
+end

--- a/lib/stripe/subscriptions/credit_note.ex
+++ b/lib/stripe/subscriptions/credit_note.ex
@@ -25,7 +25,7 @@ defmodule Stripe.CreditNote do
 
   @type discount :: %{
           amount: integer,
-          discount: String.t(),
+          discount: String.t()
         }
 
   @type t :: %__MODULE__{

--- a/lib/stripe/subscriptions/credit_note_line_item.ex
+++ b/lib/stripe/subscriptions/credit_note_line_item.ex
@@ -18,7 +18,7 @@ defmodule Stripe.CreditNoteLineItem do
 
   @type discount :: %{
           amount: integer,
-          discount: String.t(),
+          discount: String.t()
         }
 
   @type t :: %__MODULE__{

--- a/lib/stripe/subscriptions/invoice.ex
+++ b/lib/stripe/subscriptions/invoice.ex
@@ -224,7 +224,7 @@ defmodule Stripe.Invoice do
                  optional(:metadata) => Stripe.Types.metadata(),
                  optional(:payment_settings) => map,
                  optional(:statement_descriptor) => String.t(),
-                 optional(:subscription) => Stripe.id() | Stripe.Subscription.t(),
+                 optional(:subscription) => Stripe.id() | Stripe.Subscription.t()
                }
                | %{}
   def create(params, opts \\ []) do
@@ -280,7 +280,7 @@ defmodule Stripe.Invoice do
                  optional(:metadata) => Stripe.Types.metadata(),
                  optional(:paid) => boolean,
                  optional(:payment_settings) => map,
-                 optional(:statement_descriptor) => String.t(),
+                 optional(:statement_descriptor) => String.t()
                }
                | %{}
   def update(id, params, opts \\ []) do
@@ -304,7 +304,10 @@ defmodule Stripe.Invoice do
   @spec upcoming(map, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
   def upcoming(params, opts \\ [])
   def upcoming(params = %{customer: _customer}, opts), do: get_upcoming(params, opts)
-  def upcoming(params = %{customer_details: _customer_details}, opts), do: get_upcoming(params, opts)
+
+  def upcoming(params = %{customer_details: _customer_details}, opts),
+    do: get_upcoming(params, opts)
+
   def upcoming(params = %{subscription: _subscription}, opts), do: get_upcoming(params, opts)
 
   defp get_upcoming(params, opts) do

--- a/lib/stripe/subscriptions/line_item.ex
+++ b/lib/stripe/subscriptions/line_item.ex
@@ -15,11 +15,13 @@ defmodule Stripe.LineItem do
         }
 
   @type proration_details :: %{
-    credited_items: %{
-      invoice: String.t(),
-      invoice_line_items: [String.t()]
-    } | nil
-  }
+          credited_items:
+            %{
+              invoice: String.t(),
+              invoice_line_items: [String.t()]
+            }
+            | nil
+        }
 
   @type t :: %__MODULE__{
           id: Stripe.id(),

--- a/lib/stripe/subscriptions/subscription_schedule.ex
+++ b/lib/stripe/subscriptions/subscription_schedule.ex
@@ -11,7 +11,7 @@ defmodule Stripe.SubscriptionSchedule do
           billing_thresholds: Stripe.Types.collection_method_thresholds(),
           price: String.t(),
           quantity: pos_integer,
-          tax_rates: [Stripe.TaxRate.t()],
+          tax_rates: [Stripe.TaxRate.t()]
         }
 
   @type phases :: %{
@@ -78,7 +78,7 @@ defmodule Stripe.SubscriptionSchedule do
     :metadata,
     :end_behavior,
     :revision,
-    :test_clock,
+    :test_clock
   ]
 
   @plural_endpoint "subscription_schedules"
@@ -107,7 +107,8 @@ defmodule Stripe.SubscriptionSchedule do
                  %{
                    :items => [
                      %{
-                       optional(:billing_thresholds) => Stripe.Types.collection_method_thresholds(),
+                       optional(:billing_thresholds) =>
+                         Stripe.Types.collection_method_thresholds(),
                        optional(:price) => Stripe.id() | Stripe.Price.t(),
                        optional(:quantity) => non_neg_integer,
                        optional(:tax_rates) => [Stripe.TaxRate.t()]
@@ -161,7 +162,8 @@ defmodule Stripe.SubscriptionSchedule do
                  %{
                    :items => [
                      %{
-                       optional(:billing_thresholds) => Stripe.Types.collection_method_thresholds(),
+                       optional(:billing_thresholds) =>
+                         Stripe.Types.collection_method_thresholds(),
                        optional(:price) => Stripe.id() | Stripe.Price.t(),
                        optional(:quantity) => non_neg_integer,
                        optional(:tax_rates) => [Stripe.TaxRate.t()]

--- a/lib/stripe/util.ex
+++ b/lib/stripe/util.ex
@@ -62,6 +62,12 @@ defmodule Stripe.Util do
   def object_name_to_module("identity.verification_report"),
     do: Stripe.Identity.VerificationReport
 
+  def object_name_to_module("reporting.report_type"),
+    do: Stripe.Reporting.ReportType
+
+  def object_name_to_module("reporting.report_run"),
+    do: Stripe.Reporting.ReportRun
+
   def object_name_to_module("issuing.authorization"), do: Stripe.Issuing.Authorization
   def object_name_to_module("issuing.card"), do: Stripe.Issuing.Card
   def object_name_to_module("issuing.cardholder"), do: Stripe.Issuing.Cardholder

--- a/test/stripe/converter_test.exs
+++ b/test/stripe/converter_test.exs
@@ -176,7 +176,7 @@ defmodule Stripe.ConverterTest do
         %Stripe.Customer{
           address: nil,
           balance: 0,
-          created: 1656364912,
+          created: 1_656_364_912,
           currency: "usd",
           default_source: nil,
           deleted: nil,
@@ -213,6 +213,7 @@ defmodule Stripe.ConverterTest do
       total_count: nil,
       url: "/v1/customers/search"
     }
+
     fixture = Helper.load_fixture("customer_search.json")
     result = Converter.convert_result(fixture)
 

--- a/test/stripe/core_resources/charge_test.exs
+++ b/test/stripe/core_resources/charge_test.exs
@@ -10,6 +10,7 @@ defmodule Stripe.ChargeTest do
 
   test "is searchable" do
     search_query = "amount>999 AND metadata['order_id']:'6735'"
+
     assert {:ok, %Stripe.SearchResult{data: charges}} =
              Stripe.Charge.search(%{query: search_query})
 

--- a/test/stripe/core_resources/customer_test.exs
+++ b/test/stripe/core_resources/customer_test.exs
@@ -34,6 +34,7 @@ defmodule Stripe.CustomerTest do
 
   test "is searchable" do
     search_query = "name:'fakename' AND metadata['foo']:'bar'"
+
     assert {:ok, %Stripe.SearchResult{data: customers}} =
              Stripe.Customer.search(%{query: search_query})
 

--- a/test/stripe/core_resources/payment_intent_test.exs
+++ b/test/stripe/core_resources/payment_intent_test.exs
@@ -10,6 +10,7 @@ defmodule Stripe.PaymentIntentTest do
 
   test "is searchable" do
     search_query = "status:'succeeded' AND metadata['order_id']:'6735'"
+
     assert {:ok, %Stripe.SearchResult{data: payment_intents}} =
              Stripe.PaymentIntent.search(%{query: search_query})
 

--- a/test/stripe/core_resources/price_test.exs
+++ b/test/stripe/core_resources/price_test.exs
@@ -72,12 +72,12 @@ defmodule Stripe.PriceTest do
     end
   end
 
-
   describe "search/2" do
     test "searches Prices" do
       search_query = "active:'true' AND metadata['order_id']:'6735'"
+
       assert {:ok, %Stripe.SearchResult{data: prices}} =
-              Stripe.Price.search(%{query: search_query})
+               Stripe.Price.search(%{query: search_query})
 
       assert_stripe_requested(:get, "/v1/prices/search", query: [query: search_query])
       assert is_list(prices)

--- a/test/stripe/relay/product_test.exs
+++ b/test/stripe/relay/product_test.exs
@@ -3,8 +3,7 @@ defmodule Stripe.Relay.ProductTest do
 
   describe "create/2" do
     test "creates an product" do
-      assert {:ok, %Stripe.Product{}} =
-               Stripe.Relay.Product.create(%{name: "Plus"})
+      assert {:ok, %Stripe.Product{}} = Stripe.Relay.Product.create(%{name: "Plus"})
 
       assert_stripe_requested(:post, "/v1/products")
     end
@@ -51,15 +50,15 @@ defmodule Stripe.Relay.ProductTest do
   describe "search/2" do
     test "searches invoices" do
       search_query = "name:'fakename' AND metadata['foo']:'bar'"
+
       assert {:ok, %Stripe.SearchResult{data: invoices}} =
-              Stripe.Invoice.search(%{query: search_query})
+               Stripe.Invoice.search(%{query: search_query})
 
       assert_stripe_requested(:get, "/v1/invoices/search", query: [query: search_query])
       assert is_list(invoices)
       assert %Stripe.Invoice{} = hd(invoices)
     end
   end
-
 
   describe "delete/1" do
     test "deletes a product" do

--- a/test/stripe/reporting/report_run_test.exs
+++ b/test/stripe/reporting/report_run_test.exs
@@ -1,0 +1,25 @@
+defmodule Stripe.Reporting.ReportRunTest do
+  use Stripe.StripeCase, async: true
+
+  test "is creatable" do
+    assert {:ok, %Stripe.Reporting.ReportRun{}} =
+             Stripe.Reporting.ReportRun.create(%{
+               parameters: %{interval_start: 100, interval_end: 200},
+               report_type: "balance.summary.1"
+             })
+
+    assert_stripe_requested(:post, "/v1/reporting/report_runs")
+  end
+
+  test "is retrievable" do
+    assert {:ok, %Stripe.Reporting.ReportRun{}} = Stripe.Reporting.ReportRun.retrieve("frr_123")
+    assert_stripe_requested(:get, "/v1/reporting/report_runs/frr_123")
+  end
+
+  test "is listable" do
+    assert {:ok, %Stripe.List{data: report_runs}} = Stripe.Reporting.ReportRun.list()
+    assert_stripe_requested(:get, "/v1/reporting/report_runs")
+    assert is_list(report_runs)
+    assert %Stripe.Reporting.ReportRun{} = hd(report_runs)
+  end
+end

--- a/test/stripe/subscriptions/invoice_test.exs
+++ b/test/stripe/subscriptions/invoice_test.exs
@@ -111,8 +111,9 @@ defmodule Stripe.InvoiceTest do
   describe "search/2" do
     test "searches invoices" do
       search_query = "name:'fakename' AND metadata['foo']:'bar'"
+
       assert {:ok, %Stripe.SearchResult{data: invoices}} =
-              Stripe.Invoice.search(%{query: search_query})
+               Stripe.Invoice.search(%{query: search_query})
 
       assert_stripe_requested(:get, "/v1/invoices/search", query: [query: search_query])
       assert is_list(invoices)

--- a/test/stripe/subscriptions/subscription_schedule_test.exs
+++ b/test/stripe/subscriptions/subscription_schedule_test.exs
@@ -9,7 +9,7 @@ defmodule Stripe.SubscriptionScheduleTest do
         coupon: nil,
         default_tax_rates: [],
         end_date: 1_557_566_037,
-        start_date: 1_554_974_037,
+        start_date: 1_554_974_037
       }
     ]
   }
@@ -38,7 +38,7 @@ defmodule Stripe.SubscriptionScheduleTest do
                 tax_rates: []
               }
             ],
-            start_date: 1_554_974_037,
+            start_date: 1_554_974_037
           }
         ]
       }
@@ -71,7 +71,7 @@ defmodule Stripe.SubscriptionScheduleTest do
                 tax_rates: []
               }
             ],
-            start_date: 1_554_974_037,
+            start_date: 1_554_974_037
           }
         ]
       }

--- a/test/support/stripe_case.ex
+++ b/test/support/stripe_case.ex
@@ -75,7 +75,12 @@ defmodule Stripe.StripeCase do
   using do
     quote do
       import Stripe.StripeCase,
-        only: [assert_stripe_requested: 2, assert_stripe_requested: 3, get_stripe_request_headers: 0, stripe_base_url: 0]
+        only: [
+          assert_stripe_requested: 2,
+          assert_stripe_requested: 3,
+          get_stripe_request_headers: 0,
+          stripe_base_url: 0
+        ]
 
       Application.put_env(:stripity_stripe, :http_module, HackneyMock)
     end


### PR DESCRIPTION
Add [report run](https://stripe.com/docs/api/reporting/report_run) and [report type](https://stripe.com/docs/api/reporting/report_type) entities.

I also ran `mix format` to format my added code and it ended up changing quite a bit of existing code.