### PR TITLE
Add back `Subscription.delete`

### DIFF
--- a/lib/stripe/subscriptions/subscription.ex
+++ b/lib/stripe/subscriptions/subscription.ex
@@ -234,6 +234,54 @@ defmodule Stripe.Subscription do
   end
 
   @doc """
+  Delete a subscription.
+  Takes the subscription `id` or a `Stripe.Subscription` struct.
+  """
+  @spec delete(Stripe.id() | t) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def delete(id), do: delete(id, %{}, [])
+
+  @doc """
+  Delete a subscription.
+  Takes the subscription `id` or a `Stripe.Subscription` struct.
+  Second argument can be a map of cancellation `params`, such as `invoice_now`,
+  or a list of options, such as custom API key.
+  """
+
+  @spec delete(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def delete(id, opts) when is_list(opts) do
+    delete(id, %{}, opts)
+  end
+
+  @spec delete(Stripe.id() | t, params) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params: %{
+               optional(:invoice_now) => boolean,
+               optional(:prorate) => boolean
+             }
+  def delete(id, params) when is_map(params) do
+    delete(id, params, [])
+  end
+
+  @doc """
+  Delete a subscription.
+  Takes the subscription `id` or a `Stripe.Subscription` struct.
+  Second argument is a map of cancellation `params`, such as `invoice_now`.
+  Third argument is a list of options, such as custom API key.
+  """
+  @spec delete(Stripe.id() | t, params, Stripe.options()) ::
+          {:ok, t} | {:error, Stripe.Error.t()}
+        when params: %{
+               optional(:invoice_now) => boolean,
+               optional(:prorate) => boolean
+             }
+  def delete(id, params, opts) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:delete)
+    |> put_params(params)
+    |> make_request()
+  end
+
+  @doc """
   List all subscriptions.
   """
   @spec list(params, Stripe.options()) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}

--- a/test/stripe/subscriptions/subscription_test.exs
+++ b/test/stripe/subscriptions/subscription_test.exs
@@ -59,6 +59,40 @@ defmodule Stripe.SubscriptionTest do
     end
   end
 
+  describe "delete/1" do
+    test "deletes a subscription" do
+      assert {:ok, %Stripe.Subscription{} = subscription} = Stripe.Subscription.delete("sub_123")
+      assert_stripe_requested(:delete, "/v1/subscriptions/#{subscription.id}")
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a subscription when second argument is a list" do
+      assert {:ok, %Stripe.Subscription{} = subscription} =
+               Stripe.Subscription.delete("sub_123", [])
+
+      assert_stripe_requested(:delete, "/v1/subscriptions/#{subscription.id}")
+    end
+
+    test "deletes a subscription when second argument is a map" do
+      assert {:ok, %Stripe.Subscription{} = subscription} =
+               Stripe.Subscription.delete("sub_123", %{})
+
+      assert_stripe_requested(:delete, "/v1/subscriptions/#{subscription.id}")
+    end
+  end
+
+  describe "delete/3" do
+    test "deletes a subscription with provided cancellation params" do
+      params = %{invoice_now: true, prorate: true}
+
+      assert {:ok, %Stripe.Subscription{} = subscription} =
+               Stripe.Subscription.delete("sub_123", params)
+
+      assert_stripe_requested(:delete, "/v1/subscriptions/#{subscription.id}", body: params)
+    end
+  end
+
   describe "list/2" do
     test "lists all subscriptions" do
       assert {:ok, %Stripe.List{data: subscriptions}} = Stripe.Subscription.list()
@@ -71,8 +105,9 @@ defmodule Stripe.SubscriptionTest do
   describe "search/2" do
     test "searches subscriptions" do
       query = "name:'fakename' AND metadata['foo']:'bar'"
+
       assert {:ok, %Stripe.SearchResult{data: subscriptions}} =
-              Stripe.Subscription.search(%{query: query})
+               Stripe.Subscription.search(%{query: query})
 
       assert_stripe_requested(:get, "/v1/subscriptions/search", query: [query: query])
       assert is_list(subscriptions)


### PR DESCRIPTION
## Description

It seems that with the [Stripe API version upgrade](https://github.com/beam-community/stripity_stripe/pull/748) we accidentally deleted the way for subscriptions to be cancelled.
The [Stripe API docs](https://stripe.com/docs/api/subscriptions/cancel) (and their SDK) still mention the `subscription.del()`. This PR is just a recovery of the [previous version](https://github.com/beam-community/stripity_stripe/blob/1764579ea88ac5da37e11f9374a8ada6ad84cb2b/lib/stripe/subscriptions/subscription.ex#L233-L304) `&delete/1`, `&delete/2` and `&delete/3` methods (minus the deprecated params).

**Note:** I have stripped off the deprecated params as they are also not referenced in the docs anymore 👍 

Fixes https://github.com/beam-community/stripity_stripe/issues/750