### PR TITLE
Fix Specs in Stripe.API Module

### DIFF
--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -239,7 +239,7 @@ defmodule Stripe.API do
       request(%{}, :get, "/customers", %{}, connect_account: "acc_134151")
 
   """
-  @spec request(body, method, String.t(), headers, list) ::
+  @spec request(map, method, String.t(), headers, list) ::
           {:ok, map} | {:error, Stripe.Error.t()}
   def request(body, :get, endpoint, headers, opts) do
     {expansion, opts} = Keyword.pop(opts, :expand)
@@ -274,7 +274,7 @@ defmodule Stripe.API do
   @doc """
   A low level utility function to make a direct request to the files Stripe API
   """
-  @spec request_file_upload(body, method, String.t(), headers, list) ::
+  @spec request_file_upload(map, method, String.t(), headers, list) ::
           {:ok, map} | {:error, Stripe.Error.t()}
   def request_file_upload(body, :post, endpoint, headers, opts) do
     base_url = get_upload_url()


### PR DESCRIPTION
This PR fixes two typespecs that are causing dialyzer errors for consumers of the library. In each case, the functions require maps but specify a type `body`. This type is used internally.