### PR TITLE
extend Checkout Session consent collection Type

### DIFF
--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -127,8 +127,14 @@ defmodule Stripe.Session do
           promotions: String.t()
         }
 
+  @typedoc """
+  One of `"required"`, `"none"`.
+  """
+  @type consent_collection_terms_of_service :: String.t()
+  
   @type consent_collection :: %{
-          promotions: String.t()
+          promotions: String.t(),
+          terms_of_service: consent_collection_terms_of_service() | nil
         }
 
   @typedoc """


### PR DESCRIPTION
This Pull Request extends the Checkout Sessions Typespec to support the collection of the Terms of Service consent.

The Stripe API supports the collection of the Terms of Service consent, see [Stripe docs][1].

I discovered this as I was trying to use this feature but ran into dialyzer issues.

[1]: https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-consent_collection-terms_of_service