### PR TITLE
Add `adjustable_quantity` to `line_item_data` for Checkout Sessions

### DIFF
--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -159,6 +159,7 @@ defmodule Stripe.Session do
           optional(:id) => Stripe.id(),
           optional(:object) => String.t(),
           optional(:quantity) => integer(),
+          optional(:adjustable_quantity) => adjustable_quantity(),
           optional(:amount_discount) => integer(),
           optional(:amount_subtotal) => integer(),
           optional(:amount_tax) => integer(),


### PR DESCRIPTION
Hello 👋🏼 

This PR adds a missing field to the spec for `Stripe.Checkout.Session.create/2`. The relevant object already has a type, but it was not referenced until now. You can find the corresponding API docs [here](https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-line_items-adjustable_quantity).